### PR TITLE
feat/adding_items

### DIFF
--- a/internal/game/game.go
+++ b/internal/game/game.go
@@ -77,8 +77,7 @@ func (g *Game) Update() error {
 		item := g.items[i]
 		// The update function also puts collected items into the inventory
 		removeItem := item.Update(g.Player, g.inventory)
-		// Remove items after
-		// the player picked them up
+		// Remove items after the player picked them up
 		if !removeItem {
 			if n != i {
 				g.items[n] = item

--- a/internal/inventory/inventory.go
+++ b/internal/inventory/inventory.go
@@ -1,0 +1,17 @@
+package inventory
+
+import "github.com/N3moAhead/harvest/internal/itemtype"
+
+type Inventory struct {
+	Vegtables map[itemtype.ItemType]int // Mapping the item type to the amount
+}
+
+func (i *Inventory) AddVegtable(itemType itemtype.ItemType) {
+	i.Vegtables[itemType]++
+}
+
+func NewInventory() *Inventory {
+	return &Inventory{
+		Vegtables: make(map[itemtype.ItemType]int),
+	}
+}

--- a/internal/item/item.go
+++ b/internal/item/item.go
@@ -2,9 +2,10 @@ package item
 
 import (
 	"image/color"
-	"math/rand/v2"
 
 	"github.com/N3moAhead/harvest/internal/entity"
+	"github.com/N3moAhead/harvest/internal/inventory"
+	"github.com/N3moAhead/harvest/internal/itemtype"
 	"github.com/N3moAhead/harvest/internal/player"
 	"github.com/N3moAhead/harvest/pkg/config"
 	"github.com/hajimehoshi/ebiten/v2"
@@ -14,43 +15,50 @@ import (
 type Item struct {
 	entity.Entity
 
-	Type ItemType
+	Type itemtype.ItemType
 }
 
-func (i *Item) Update(player *player.Player) {
-	// distance to player
+func (i *Item) Update(player *player.Player, inventory *inventory.Inventory) (removeItem bool) {
 	diff := player.Pos.Sub(i.Pos)
-	len := diff.Len()
+	len := diff.Len() // the distance from player to item
 	if len < player.MagnetRadius {
-		// Move towards player
 		dir := diff.Normalize()
+		// Moving the item towards the player using the correct speed
 		i.Pos = i.Pos.Add(dir.Mul(config.PLAYER_MAGNET_ATTRACTION_SPEED))
+		if len < config.PLAYER_PICKUP_RADIUS {
+			// Picking up the item into the inventory
+			inventory.AddVegtable(i.Type)
+			return true
+		}
 	}
-	// Check if the item is in the magnet radius of the player
-	// if so move the item closer to the player
-	// if the item is in the pickup radius of the player
-	// move it into his inventory
+	return false
 }
 
 func (i *Item) Draw(screen *ebiten.Image, mapOffsetX float64, mapOffsetY float64) {
+	var itemColor color.RGBA
+	switch {
+	case i.Type == itemtype.Carrot:
+		itemColor = color.RGBA{R: 230, G: 126, B: 34, A: 255}
+	case i.Type == itemtype.Potato:
+		itemColor = color.RGBA{R: 183, G: 146, B: 104, A: 255}
+	default:
+		itemColor = color.RGBA{R: 255, G: 255, B: 255, A: 255}
+	}
 	vector.DrawFilledRect(
 		screen,
-		float32(i.Pos.X)-float32(mapOffsetX)-16.0,
-		float32(i.Pos.Y)-float32(mapOffsetY)-16.0,
-		32.0,
-		32.0,
-		color.RGBA{R: 255, G: 255, B: 255, A: 255},
+		float32(i.Pos.X)-float32(mapOffsetX)-4.0,
+		float32(i.Pos.Y)-float32(mapOffsetY)-4.0,
+		8.0,
+		8.0,
+		itemColor,
 		true,
 	)
 }
 
-func newItemBase() *Item {
-	// For testing items will spawn randomly on the map
-	// random float64 between 0 and 1280
-	posX := rand.Float64() * config.WIDTH_IN_TILES * config.TILE_SIZE
-	posY := rand.Float64() * config.HEIGHT_IN_TILES * config.TILE_SIZE
+func newItemBase(posX float64, posY float64) *Item {
 	baseClass := entity.NewEntity(posX, posY)
 	return &Item{
 		Entity: *baseClass,
+		Type:   itemtype.Undefined,
 	}
 }

--- a/internal/item/item.go
+++ b/internal/item/item.go
@@ -21,15 +21,22 @@ type Item struct {
 func (i *Item) Update(player *player.Player, inventory *inventory.Inventory) (removeItem bool) {
 	diff := player.Pos.Sub(i.Pos)
 	len := diff.Len() // the distance from player to item
+	if len < config.PLAYER_PICKUP_RADIUS {
+		// Picking up the item into the inventory
+		inventory.AddVegtable(i.Type)
+		return true
+	}
 	if len < player.MagnetRadius {
-		dir := diff.Normalize()
-		// Moving the item towards the player using the correct speed
-		i.Pos = i.Pos.Add(dir.Mul(config.PLAYER_MAGNET_ATTRACTION_SPEED))
-		if len < config.PLAYER_PICKUP_RADIUS {
-			// Picking up the item into the inventory
-			inventory.AddVegtable(i.Type)
-			return true
+		dir := diff.Normalize() // Direction towards the player
+		// Calculating movement towards the player with the correct speed
+		moveStep := dir.Mul(config.PLAYER_MAGNET_ATTRACTION_SPEED)
+		// Avoid overshooting the target
+		if moveStep.Len() > len {
+			i.Pos = player.Pos
+		} else {
+			i.Pos = i.Pos.Add(moveStep)
 		}
+
 	}
 	return false
 }

--- a/internal/item/item.go
+++ b/internal/item/item.go
@@ -1,0 +1,56 @@
+package item
+
+import (
+	"image/color"
+	"math/rand/v2"
+
+	"github.com/N3moAhead/harvest/internal/entity"
+	"github.com/N3moAhead/harvest/internal/player"
+	"github.com/N3moAhead/harvest/pkg/config"
+	"github.com/hajimehoshi/ebiten/v2"
+	"github.com/hajimehoshi/ebiten/v2/vector"
+)
+
+type Item struct {
+	entity.Entity
+
+	Type ItemType
+}
+
+func (i *Item) Update(player *player.Player) {
+	// distance to player
+	diff := player.Pos.Sub(i.Pos)
+	len := diff.Len()
+	if len < player.MagnetRadius {
+		// Move towards player
+		dir := diff.Normalize()
+		i.Pos = i.Pos.Add(dir.Mul(config.PLAYER_MAGNET_ATTRACTION_SPEED))
+	}
+	// Check if the item is in the magnet radius of the player
+	// if so move the item closer to the player
+	// if the item is in the pickup radius of the player
+	// move it into his inventory
+}
+
+func (i *Item) Draw(screen *ebiten.Image, mapOffsetX float64, mapOffsetY float64) {
+	vector.DrawFilledRect(
+		screen,
+		float32(i.Pos.X)-float32(mapOffsetX)-16.0,
+		float32(i.Pos.Y)-float32(mapOffsetY)-16.0,
+		32.0,
+		32.0,
+		color.RGBA{R: 255, G: 255, B: 255, A: 255},
+		true,
+	)
+}
+
+func newItemBase() *Item {
+	// For testing items will spawn randomly on the map
+	// random float64 between 0 and 1280
+	posX := rand.Float64() * config.WIDTH_IN_TILES * config.TILE_SIZE
+	posY := rand.Float64() * config.HEIGHT_IN_TILES * config.TILE_SIZE
+	baseClass := entity.NewEntity(posX, posY)
+	return &Item{
+		Entity: *baseClass,
+	}
+}

--- a/internal/item/types.go
+++ b/internal/item/types.go
@@ -1,0 +1,20 @@
+package item
+
+type ItemType int
+
+const (
+	Carrot ItemType = iota
+	Potato
+)
+
+func NewCarrot() *Item {
+	newItem := newItemBase()
+	newItem.Type = Carrot
+	return newItem
+}
+
+func NewPotato() *Item {
+	newItem := newItemBase()
+	newItem.Type = Potato
+	return newItem
+}

--- a/internal/item/types.go
+++ b/internal/item/types.go
@@ -1,20 +1,15 @@
 package item
 
-type ItemType int
+import "github.com/N3moAhead/harvest/internal/itemtype"
 
-const (
-	Carrot ItemType = iota
-	Potato
-)
-
-func NewCarrot() *Item {
-	newItem := newItemBase()
-	newItem.Type = Carrot
+func NewCarrot(posX float64, posY float64) *Item {
+	newItem := newItemBase(posX, posY)
+	newItem.Type = itemtype.Carrot
 	return newItem
 }
 
-func NewPotato() *Item {
-	newItem := newItemBase()
-	newItem.Type = Potato
+func NewPotato(posX float64, posY float64) *Item {
+	newItem := newItemBase(posX, posY)
+	newItem.Type = itemtype.Potato
 	return newItem
 }

--- a/internal/itemtype/itemtype.go
+++ b/internal/itemtype/itemtype.go
@@ -6,7 +6,7 @@ type ItemCategory int
 
 const (
 	CategoryUndefined ItemCategory = iota
-	CategoryVegtable
+	CategoryVegetable
 	CategoryWeopon
 	CategorySoup // Or could also be named buff
 )
@@ -15,7 +15,7 @@ func (ic ItemCategory) String() string {
 	switch ic {
 	case CategoryUndefined:
 		return "Undefined"
-	case CategoryVegtable:
+	case CategoryVegetable:
 		return "Vegtable"
 	case CategoryWeopon:
 		return "Weopon"
@@ -40,8 +40,8 @@ var itemInfo = map[ItemType]struct {
 	DisplayName string
 	Category    ItemCategory
 }{
-	Potato: {"Potato", CategoryVegtable},
-	Carrot: {"Carrot", CategoryVegtable},
+	Potato: {"Potato", CategoryVegetable},
+	Carrot: {"Carrot", CategoryVegetable},
 }
 
 func (it ItemType) String() string {
@@ -59,7 +59,7 @@ func (it ItemType) Category() ItemCategory {
 }
 
 func (it ItemType) IsVegtable() bool {
-	return it.Category() == CategoryVegtable
+	return it.Category() == CategoryVegetable
 }
 
 func (it ItemType) IsWeopon() bool {

--- a/internal/itemtype/itemtype.go
+++ b/internal/itemtype/itemtype.go
@@ -7,7 +7,7 @@ type ItemCategory int
 const (
 	CategoryUndefined ItemCategory = iota
 	CategoryVegetable
-	CategoryWeopon
+	CategoryWeapon
 	CategorySoup // Or could also be named buff
 )
 
@@ -17,8 +17,8 @@ func (ic ItemCategory) String() string {
 		return "Undefined"
 	case CategoryVegetable:
 		return "Vegtable"
-	case CategoryWeopon:
-		return "Weopon"
+	case CategoryWeapon:
+		return "Weapon"
 	case CategorySoup:
 		return "Soup"
 	default:
@@ -62,8 +62,8 @@ func (it ItemType) IsVegtable() bool {
 	return it.Category() == CategoryVegetable
 }
 
-func (it ItemType) IsWeopon() bool {
-	return it.Category() == CategoryWeopon
+func (it ItemType) IsWeapon() bool {
+	return it.Category() == CategoryWeapon
 }
 
 func (it ItemType) IsSoup() bool {

--- a/internal/itemtype/itemtype.go
+++ b/internal/itemtype/itemtype.go
@@ -1,0 +1,71 @@
+package itemtype
+
+import "fmt"
+
+type ItemCategory int
+
+const (
+	CategoryUndefined ItemCategory = iota
+	CategoryVegtable
+	CategoryWeopon
+	CategorySoup // Or could also be named buff
+)
+
+func (ic ItemCategory) String() string {
+	switch ic {
+	case CategoryUndefined:
+		return "Undefined"
+	case CategoryVegtable:
+		return "Vegtable"
+	case CategoryWeopon:
+		return "Weopon"
+	case CategorySoup:
+		return "Soup"
+	default:
+		return "Unknown"
+	}
+}
+
+type ItemType int
+
+const (
+	Undefined ItemType = iota
+	Potato
+	Carrot
+)
+
+// Saves meta information for each item type
+// To help us connect Categories and ItemTypes
+var itemInfo = map[ItemType]struct {
+	DisplayName string
+	Category    ItemCategory
+}{
+	Potato: {"Potato", CategoryVegtable},
+	Carrot: {"Carrot", CategoryVegtable},
+}
+
+func (it ItemType) String() string {
+	if info, ok := itemInfo[it]; ok {
+		return info.DisplayName
+	}
+	return fmt.Sprintf("ItemType(%d)", it)
+}
+
+func (it ItemType) Category() ItemCategory {
+	if info, ok := itemInfo[it]; ok {
+		return info.Category
+	}
+	return CategoryUndefined
+}
+
+func (it ItemType) IsVegtable() bool {
+	return it.Category() == CategoryVegtable
+}
+
+func (it ItemType) IsWeopon() bool {
+	return it.Category() == CategoryWeopon
+}
+
+func (it ItemType) IsSoup() bool {
+	return it.Category() == CategorySoup
+}

--- a/internal/player/player.go
+++ b/internal/player/player.go
@@ -14,8 +14,9 @@ import (
 type Player struct {
 	entity.Entity
 
-	Speed  float64
-	Health component.Health
+	Speed        float64
+	MagnetRadius float64
+	Health       component.Health
 }
 
 // The player is currently just drawn as a rectangle.
@@ -49,9 +50,10 @@ func NewPlayer() *Player {
 	baseEntity := entity.NewEntity(config.SCREEN_WIDTH/2, config.SCREEN_HEIGHT/2)
 
 	p := &Player{
-		Entity: *baseEntity,
-		Speed:  config.INITIAL_PLAYER_SPEED,
-		Health: component.NewHealth(100),
+		Entity:       *baseEntity,
+		MagnetRadius: config.INITIAL_PLAYER_MAGNET_RADIUS,
+		Speed:        config.INITIAL_PLAYER_SPEED,
+		Health:       component.NewHealth(100),
 	}
 	return p
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -14,9 +14,9 @@ const (
 	WIDTH_IN_TILES  = 40 // The number of tiles in the Y direction.
 	/// --- Player Settings ---
 	INITIAL_PLAYER_SPEED           = 6.0 // Initial Player Speed
-	INITIAL_PLAYER_MAGNET_RADIUS   = 150.0
-	PLAYER_PICKUP_RADIUS           = 50.0 // The radius in which items will be picked up into the players inventory
-	PLAYER_MAGNET_ATTRACTION_SPEED = 10.0 // Determines how fast items move towards the player
+	INITIAL_PLAYER_MAGNET_RADIUS   = 50.0
+	PLAYER_PICKUP_RADIUS           = 5.0 // The radius in which items will be picked up into the players inventory
+	PLAYER_MAGNET_ATTRACTION_SPEED = 7.0 // Determines how fast items move towards the player
 	/// --- Audio Settings ---
 	AUDIO_SAMPLE_RATE = 44100
 )

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -3,16 +3,20 @@ package config
 // Currently just fixed constant values. PLS do not overuse it.
 // TODO: Implement functions to read the config from a toml or json file
 const (
+	/// --- Window Settings ---
 	SCREEN_WIDTH  = 700
 	SCREEN_HEIGHT = 700
-	CAMERA_SPEED  = 4.0
-	// TILE_SIZE is the size of a tile in pixels.
-	TILE_SIZE = 32
-	// The number of tiles in the X direction.
-	HEIGHT_IN_TILES = 40
-	// The number of tiles in the Y direction.
-	WIDTH_IN_TILES = 40
-	// Initial Player Speed
-	INITIAL_PLAYER_SPEED = 6.0
-	AUDIO_SAMPLE_RATE    = 44100
+	/// --- Camera Settings ---
+	CAMERA_SPEED = 4.0
+	/// --- World Settings ---
+	TILE_SIZE       = 32 // TILE_SIZE is the size of a tile in pixels.
+	HEIGHT_IN_TILES = 40 // The number of tiles in the X direction.
+	WIDTH_IN_TILES  = 40 // The number of tiles in the Y direction.
+	/// --- Player Settings ---
+	INITIAL_PLAYER_SPEED           = 6.0 // Initial Player Speed
+	INITIAL_PLAYER_MAGNET_RADIUS   = 150.0
+	PLAYER_PICKUP_RADIUS           = 50.0 // The radius in which items will be picked up into the players inventory
+	PLAYER_MAGNET_ATTRACTION_SPEED = 10.0 // Determines how fast items move towards the player
+	/// --- Audio Settings ---
+	AUDIO_SAMPLE_RATE = 44100
 )


### PR DESCRIPTION
I added items into the game

Items can be divided into multiple categories.

A player has a magnet radius which can be configured in the config. Items inside this radius will be moved towards the player. Items that are close enough to the player (PickupRadius) will be moved into the inventory.

For Testing Items can be spawned by pressing k.

In a further Pull Request  i will implement a chunking system, so we dont have to check every item on the ground or later on every enemy on the field.
